### PR TITLE
Add method to retrieve Steam path via Windows registry

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -272,6 +272,7 @@ version = "1.1.0"
 dependencies = [
  "tauri",
  "tauri-build",
+ "winreg",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
 tauri = { version = "1.5.2", features = [ "protocol-asset", "path-all", "fs-read-file", "fs-create-dir", "fs-copy-file", "fs-write-file", "dialog-open", "fs-exists", "objc-exception", "wry"], default-features = false}
+winreg = "0.52.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem


### PR DESCRIPTION
This pull request completes issue #12.

I have incorporated the `winreg` library to securely access the Windows registry. In addition, I have optimized the `read_steam_vdf` function, integrating this enhancement, and I have developed a new function called `get_steam_path`, which allows to retrieve the Steam library path directly from the Windows registry.